### PR TITLE
Fixed the component in Modal that used CascadingParameter to receive parameters, with a null parameter value

### DIFF
--- a/components/modal/modalDialog/Modal.razor.cs
+++ b/components/modal/modalDialog/Modal.razor.cs
@@ -326,12 +326,12 @@ namespace AntDesign
 
         public override async Task SetParametersAsync(ParameterView parameters)
         {
+            await base.SetParametersAsync(parameters);
+            
             var visibleChanged = parameters.IsParameterChanged(nameof(Visible), Visible, out var newVisible);
 
             parameters.SetParameterProperties(this);
             
-            await base.SetParametersAsync(parameters);
-
             if (_modalRef == null)
             {
                 var options = BuildDialogOptions();

--- a/components/modal/modalDialog/Modal.razor.cs
+++ b/components/modal/modalDialog/Modal.razor.cs
@@ -329,6 +329,8 @@ namespace AntDesign
             var visibleChanged = parameters.IsParameterChanged(nameof(Visible), Visible, out var newVisible);
 
             parameters.SetParameterProperties(this);
+            
+            await base.SetParametersAsync(parameters);
 
             if (_modalRef == null)
             {


### PR DESCRIPTION
Fixed the component in Modal that used CascadingParameter to receive parameters, with a null parameter value